### PR TITLE
connecting geopandas parts

### DIFF
--- a/cenpy/tiger.py
+++ b/cenpy/tiger.py
@@ -157,7 +157,7 @@ class ESRILayer(object):
             todf.append(locfeat['properties'])
             todf[i].update({'geometry':locfeat['geometry']})
         df = pd.DataFrame(todf)
-        outdf = gpsr.convert_geometries(df)
+        outdf = gpsr.convert_geometries(df, pkg)
         if gpize:
             try:
                 from geopandas import GeoDataFrame


### PR DESCRIPTION
Currently the `convert_geometries()` function is not getting the `pkg` flag, and so the geometries are "always" (at least in my tests) output as pysal shape objects. This PR allows the `shapely` flag to pass through and thus allow geopandas output.