### PR TITLE
Bugfix release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,11 @@ before_install:
     - ./miniconda.sh -b -p ./miniconda
     - export PATH=`pwd`/miniconda/bin:$PATH
     - conda update --yes conda
-    - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION numpy pandas six pip requests nose
+    - conda create -y -q -n test-env python=$TRAVIS_PYTHON_VERSION numpy scipy pandas six pip requests nose
     - source activate test-env
+    - conda install -y -c osgeo gdal
+    - pip install geopandas
+    - pip install pysal 
     - python -c 'import requests; print(requests.__version__)'
     - python -c 'import pandas; print(pandas.__version__)'
 

--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,4 +1,5 @@
 pandas
+geopandas
 request
 numpy
 six

--- a/cenpy/remote.py
+++ b/cenpy/remote.py
@@ -145,9 +145,7 @@ class APIConnection():
 
         if geo_filter != {}:
             self.last_query += '&in='
-            for key,value in iteritems(geo_filter):
-                self.last_query += key + ':' + value + '+'
-            self.last_query = self.last_query.rstrip('+')
+            self.last_query += '+'.join([':'.join(kvpair) for kvpair in iteritems(geo_filter)])
 
         if apikey != '':
             self.last_query += '&key=' + apikey

--- a/cenpy/remote.py
+++ b/cenpy/remote.py
@@ -147,6 +147,7 @@ class APIConnection():
             self.last_query += '&in='
             for key,value in iteritems(geo_filter):
                 self.last_query += key + ':' + value + '+'
+            self.last_query = self.last_query.rstrip('+')
 
         if apikey != '':
             self.last_query += '&key=' + apikey

--- a/cenpy/tests/test_functional.py
+++ b/cenpy/tests/test_functional.py
@@ -1,0 +1,81 @@
+# # Downloading and Plotting U.S. Census Bureau Data Using Python
+# David C. Folch | Florida State University | github: @dfolch
+# 
+# Rebecca Davies | University of Colorado Boulder | github: @beckymasond
+
+import pandas as pd
+import cenpy as cen
+
+
+databases = [(k,v) for k,v in cen.explorer.available(verbose=True).items()]
+print('total number of databases:', len(databases))
+databases[0:5]
+
+api_database = 'ACSSF5Y2012'  # ACS 2008-2012
+
+
+cen.explorer.explain(api_database)
+
+api_conn = cen.base.Connection(api_database)
+
+queries = []
+g_unit = 'state'
+g_filter = {}
+queries.append((g_unit, g_filter))
+### select Florida
+g_unit = 'state:12'
+g_filter = {}
+queries.append((g_unit, g_filter))
+### select all counties in Florida
+g_unit = 'county'
+g_filter = {'state':'12'}
+### select all census tracts in Florida
+g_unit = 'tract'
+queries.append((g_unit, g_filter))
+g_filter = {'state':'12'}
+### select all tracts in Leon County, Florida
+g_unit = 'tract'
+g_filter = {'state':'12', 'county':'073'}
+queries.append((g_unit, g_filter))
+
+cols = api_conn.varslike('B17006_\S+')
+cols.extend(api_conn.varslike('B19326_\S+'))
+
+cols_detail = pd.DataFrame(api_conn.variables.loc[cols].label)
+cols_detail.head()
+
+cols.extend(['NAME', 'GEOID'])
+
+for query in queries:
+    geo_unit, geo_filter = query
+    data = api_conn.query(cols, geo_unit=g_unit, geo_filter=g_filter)
+    print(data.head())
+    data.index = data.GEOID
+    data.index = data.index.str.replace('14000US','')
+    data[['B17006_012E','B17006_012M']].head(10)
+
+
+cen.tiger.available()
+api_conn.set_mapservice('tigerWMS_ACS2013')
+api_conn
+
+
+# The ACS produces estimates from many different geographies.
+
+# In[25]:
+
+api_conn.mapservice.layers
+
+
+api_conn.mapservice.layers[8]
+
+### select Florida
+#geodata = api_conn.mapservice.query(layer=82, where='STATE=12', pkg='geopandas')
+#### select all counties in Florida
+#geodata = api_conn.mapservice.query(layer=84, where='STATE=12')
+#### select all census tracts in Florida
+#geodata = api_conn.mapservice.query(layer=8, where='STATE=12', pkg='geopandas')
+### select all tracts in Leon County, Florida
+geodata = api_conn.mapservice.query(layer=8, where='STATE=12 and COUNTY=073')
+
+newdata = pd.merge(data, geodata, left_index=True, right_on='GEOID')

--- a/cenpy/tiger.py
+++ b/cenpy/tiger.py
@@ -150,7 +150,17 @@ class ESRILayer(object):
         resp.raise_for_status()
         datadict = resp.json()
     #convert to output format
-        features = datadict['features']
+        try:
+            features = datadict['features']
+        except KeyError:
+            code, msg = datadict['error']['code'], datadict['error']['message']
+            details = datadict['error']['details']
+            if details is []:
+                details = 'Mapserver provided no detailed error'
+            raise KeyError(('Response from API is malformed. You may have '
+                            'submitted too many queries, or experienced '
+                            'significant network connectivity issues.\n'
+                            '(API ERROR {}:{}({}))'.format(code, msg, details)))
         todf = []
         for i, feature in enumerate(features):
             locfeat = gpsr.__dict__[datadict['geometryType']](feature)

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup
 
 setup(name='cenpy',
-        version='0.9.1',
+        version='0.9.2',
       description='Explore and download data from Census APIs',
       url='https://github.com/ljwolf/cenpy',
       author='Levi John Wolf',
       author_email='levi.john.wolf@gmail.com',
       license='3-Clause BSD',
       packages=['cenpy'],
-      install_requires=['pandas', 'requests'],
+      install_requires=['pandas', 'requests', 'pysal'],
       package_data={'cenpy': ['stfipstable.csv']},
       zip_safe=False)


### PR DESCRIPTION
query strings had a terminal `+`, which is now not accepted by the API. 

This PR removes the terminal `+` in the query string generator.

In addition, due to the way the geoAPI was queried, some HTTP errors are encoded in valid JSON first and then sent, rather than being sent as normal HTTP errors. This results in a `requests` response that does not fail when `.raise_for_status()` was called, but contains a JSON-encoding of the failure code, message, and detailed status.

So, this failure is now detected and its relevant information raised.