### PR TITLE
Fix setup.py to keep install consistent with testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup
 
 setup(name='cenpy',
-        version='0.9.7',
+      version='0.9.7',
       description='Explore and download data from Census APIs',
       url='https://github.com/ljwolf/cenpy',
       author='Levi John Wolf',
       author_email='levi.john.wolf@gmail.com',
       license='3-Clause BSD',
-      python_requires='>=3.4',
+      python_requires='>=3.5',
       packages=['cenpy'],
       install_requires=['pandas', 'requests', 'pysal'],
       package_data={'cenpy': ['stfipstable.csv']},


### PR DESCRIPTION
Originally was able to install with Python 3.4.2, despite ``json.JSONDecodeError`` being a required import that is missing in Python 3.4. See #20. 