### PR TITLE
switch to infer_objects and add default table parser for explain

### DIFF
--- a/cenpy/explorer.py
+++ b/cenpy/explorer.py
@@ -13,7 +13,7 @@ raw_APIs = r.get('https://api.census.gov/data.json').json()['dataset']
 
 APIs = {entry['identifier'].split('id')[-1].lstrip('/'): {key: value for key,value in diter(entry) if key != entry['identifier']} for entry in raw_APIs}
 
-def available(verbose=False):
+def available(verbose=True):
     """
     Returns available identifiers for Census Data APIs. 
     NOTE: we do not support the Economic Indicators Time Series API yet.
@@ -32,9 +32,39 @@ def available(verbose=False):
     av_apis = [api for api in APIs.keys() if 'eits' not in api]
     av_apis = [api for api in av_apis if APIs[api]['distribution'][0]['format'] == 'API']
     if verbose:
-        return {idx: APIs[idx]['title'] for idx in av_apis}
+        return _parse_results_table_from_response(raw_APIs)
     else:
         return av_apis
+
+def _parse_results_table_from_response(datajson):
+    """ parse the raw data.json response into something more useful """
+    raw_table = pd.DataFrame(raw_APIs)
+    shortcodes = [entry['identifier'].split('id')[-1].lstrip('/') 
+                  for entry in raw_APIs]
+    raw_table.index = shortcodes
+    raw_table = raw_table[[col for col in raw_table.columns if not col.startswith('@')]]
+    listcols = raw_table.applymap(lambda x: isinstance(x, list)).any()
+    listcols = listcols.index[listcols]
+    raw_table[listcols] = raw_table[listcols].apply(_delist)
+    raw_table['publisher'] = raw_table['publisher'].apply(lambda x: x.get('name', None))
+    raw_table.rename(columns=dict(identifier='identifier_url',
+                                  c_vintage = 'vintage'), inplace=True)
+    for col in raw_table:
+        if isinstance(raw_table[col].iloc[0], str):
+            if raw_table[col].iloc[0].startswith('http://'):
+                raw_table.drop(col, axis=1, inplace=True)
+    return raw_table[raw_table.columns[::-1]]
+    
+
+def _delist(series):
+    """ turn listed cols into tuples, or extract their single element """
+    series = series.copy(deep=True)
+    lens = series.dropna().apply(len).unique()
+    if len(lens) > 1: # cast to tuples
+        series[~series.isnull()] = series.dropna().apply(tuple)
+    elif len(lens) == 1 and lens.item() == 1: # grab single element
+        series[~series.isnull()] = series.dropna().apply(lambda x: x[0])
+    return series
 
 def explain(identifier=None, verbose=False):
     """

--- a/cenpy/remote.py
+++ b/cenpy/remote.py
@@ -168,7 +168,8 @@ class APIConnection():
         try:
             res = res.json()
             df = pd.DataFrame().from_records(res[1:], columns=res[0])
-            df[cols] = df[cols].convert_objects(convert_numeric=convert_numeric)
+            if convert_numeric:
+                df[cols] = df[cols].infer_objects()
             if index is not '':
                 df.index = df[index]
             return df

--- a/cenpy/tests/test_explorer.py
+++ b/cenpy/tests/test_explorer.py
@@ -1,6 +1,7 @@
 import unittest
 import cenpy
 from six import iteritems as diter
+import pandas
 import six
 
 if six.PY3:
@@ -13,7 +14,7 @@ class TestExplorer(unittest.TestCase):
     This tests the explorer module
     """
     def setUp(self):
-        self.av = cenpy.explorer.available()
+        self.av = cenpy.explorer.available(verbose=False)
         self.avv = cenpy.explorer.available(verbose=True)
     
     def test_available(self):
@@ -22,13 +23,9 @@ class TestExplorer(unittest.TestCase):
         for name in self.av:
             self.assertIsInstance(name, testtype)
         
-        self.assertIsInstance(self.avv, dict)
+        self.assertIsInstance(self.avv, pandas.DataFrame)
         self.assertNotEqual(len(self.avv), 0)
-        for k,v in diter(self.avv):
-            self.assertIsInstance(k, testtype)
-            self.assertNotEqual(len(k), 0) 
-            self.assertIsInstance(v, testtype)
-            self.assertNotEqual(len(v), 0)
+        self.assertEqual(self.avv.columns[0].lower(), 'title')
 
     def test_explain(self):
         explaintext = cenpy.explorer.explain(self.av[0])

--- a/cenpy/tests/test_remote.py
+++ b/cenpy/tests/test_remote.py
@@ -3,7 +3,7 @@ import cenpy
 
 class test_remote(unittest.TestCase):
     def test_connection(self):
-        cenpy.base.Connection(cenpy.explorer.available()[0])
+        cenpy.base.Connection(cenpy.explorer.available(verbose=False)[0])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds a table parser by default to `cenpy.explore.available()`, which should hopefully make it easier to understand the available API endpoints. 

This also addresses #25