### PR TITLE
pysal geometry vertices fix

### DIFF
--- a/cenpy/geoparser.py
+++ b/cenpy/geoparser.py
@@ -89,7 +89,9 @@ def parse_polygon_to_pysal(raw_feature):
     """
     pgon_type, ogc_nest = _get_polygon_type(raw_feature)
     from pysal.cg import Polygon
-    if pgon_type in ('Polygon', 'MultiPolygon'):
+    if pgon_type == 'Polygon':
+        return Polygon([(c[0],c[1]) for c in ogc_nest])
+    elif pgon_type == 'MultiPolygon':
         return Polygon(ogc_nest)
     elif pgon_type == 'Polygon with Holes':
         return Polygon(ogc_nest[0], holes=ogc_nest[1:])

--- a/cenpy/geoparser.py
+++ b/cenpy/geoparser.py
@@ -92,9 +92,16 @@ def parse_polygon_to_pysal(raw_feature):
     if pgon_type == 'Polygon':
         return Polygon([(c[0],c[1]) for c in ogc_nest])
     elif pgon_type == 'MultiPolygon':
-        return Polygon(ogc_nest)
+        polygons = []
+        for p in ogc_nest:
+            polygons.append([(c[0],c[1]) for c in p])
+        return Polygon(polygons)
     elif pgon_type == 'Polygon with Holes':
-        return Polygon(ogc_nest[0], holes=ogc_nest[1:])
+        polygon = [(c[0],c[1]) for c in ogc_nest[0]]
+        holes = []
+        for hole in ogc_nest[1:]:
+            holes.append([(c[0],c[1]) for c in hole])
+        return Polygon(polygon, holes=holes)
     elif pgon_type == 'MultiPolygon with Holes':
         # return ogc_nest
         return Polygon(vertices = [ring[0] for ring in ogc_nest], 


### PR DESCRIPTION
Hi, first things first: thanks for creating this awesome library! It made working with census data easy and fun.

While working with the pysal geometry objects created by the mapservice, I kept getting errors when trying to execute the pysal geometry functions (like for example, `bounding_box` calculation). This PRs unit tests have the code that would trigger this exception I was seeing:

```
...
  File "./venv/lib/python3.6/site-packages/pysal/cg/shapes.py", line 1271, in bounding_box
    x = [v[0] for v in vertices]
  File "./venv/lib/python3.6/site-packages/pysal/cg/shapes.py", line 1271, in <listcomp>
    x = [v[0] for v in vertices]
TypeError: 'float' object is not subscriptable
```

After some debugging it seems that the pysal objects are created successfully but their internal vertices list is not initialized correctly.  So when pysal tries to do some work with the vertices, it unfortunately crashes. 

The fix seems to be pretty straight-forward: simply re-arranging the initialization arrays to a format that pysal likes.  This PR's changes to `parse_polygon_to_pysal()` do exactly that.

Thanks again and I look forward to your feedback!