### PR TITLE
[WIP] support legacy tiger boundaries

### DIFF
--- a/cenpy/legacy_tiger.py
+++ b/cenpy/legacy_tiger.py
@@ -188,7 +188,9 @@ class FTPConnection(object):
         # Cleanup
 
         shp_ds.Destroy()
+        shp_ds = None
         ds.Destroy()
+        ds = None
 
         # build a fully-qualified fips code and dissolve on it to create tract geographies
         gdf = gpd.read_file(outfile)
@@ -207,7 +209,7 @@ class FTPConnection(object):
         gdf = gdf.dissolve(by='fips')
         gdf.reset_index(inplace=True)
 
-        gdf.to_file(outfile)
+        shp_driver.DeleteDataSource(outfile)
 
         return gdf
 

--- a/cenpy/legacy_tiger.py
+++ b/cenpy/legacy_tiger.py
@@ -10,12 +10,16 @@ import tempfile
 
 
 class FTPConnection(object):
-
     def __init__(self, year, statenum, stateabbr, county):
 
-        url = {2000: 'ftp://ftp2.census.gov/geo/tiger/TIGER2003/{statenum}_{stateabbr}/tgr{statenum}{county}.zip' .format(statenum=statenum, stateabbr=stateabbr, county=county),
-               1990: 'ftp://ftp2.census.gov/geo/tiger/TIGER1992/{statenum}/{statenum}{county}.zip' .format(statenum=statenum, stateabbr=stateabbr, county=county)
-               }
+        url = {
+            2000:
+            'https://www2.census.gov/geo/tiger/TIGER2003/{statenum}_{stateabbr}/tgr{statenum}{county}.zip'.
+            format(statenum=statenum, stateabbr=stateabbr, county=county),
+            1990:
+            'https://www2.census.gov/geo/tiger/TIGER1992/{statenum}/{statenum}{county}.zip'.
+            format(statenum=statenum, stateabbr=stateabbr, county=county)
+        }
 
         self.url = url[year]
         self.statenum = statenum
@@ -27,10 +31,10 @@ class FTPConnection(object):
         # Modified from original at
         # https://svn.osgeo.org/gdal/tags/1.4.3/gdal/pymod/samples/tigerpoly.py
 
-        class Module:
-            def __init__(self):
-                self.lines = {}
-                self.poly_line_links = {}
+        class Module(object):
+            def __init__(mod):
+                mod.lines = {}
+                mod.poly_line_links = {}
 
         outfile = 'tracts.shp'
 
@@ -46,7 +50,8 @@ class FTPConnection(object):
         shp_driver.DeleteDataSource(outfile)
 
         shp_ds = shp_driver.CreateDataSource(outfile)
-        shp_layer = shp_ds.CreateLayer('out', geom_type=ogr.wkbPolygon, srs=nad83)
+        shp_layer = shp_ds.CreateLayer(
+            'out', geom_type=ogr.wkbPolygon, srs=nad83)
 
         src_defn = poly_layer.GetLayerDefn()
         poly_field_count = src_defn.GetFieldCount()
@@ -183,8 +188,6 @@ class FTPConnection(object):
         if degenerate_count:
             warn('Discarded %d degenerate polygons.' % degenerate_count)
 
-        print('Built %d polygons.' % poly_count)
-
         # Cleanup
 
         shp_ds.Destroy()
@@ -220,10 +223,12 @@ class FTPConnection(object):
                 shutil.copyfileobj(response, tmp_file)
                 with tempfile.TemporaryDirectory() as tempdir:
                     ZipFile(tmp_file, 'r').extractall(tempdir)
-                    fn = os.path.join(tempdir,"TGR{statenum}{county}" .format(statenum=self.statenum, county=self.county))
-                    if os.path.exists(fn+".RTA"):
-                        tracts = self._tiger_to_tract(fn+".RTA")
+                    fn = os.path.join(
+                        tempdir, "TGR{statenum}{county}".format(
+                            statenum=self.statenum, county=self.county))
+                    if os.path.exists(fn + ".RTA"):
+                        tracts = self._tiger_to_tract(fn + ".RTA")
                     else:
-                        tracts = self._tiger_to_tract(fn+".F5A")
+                        tracts = self._tiger_to_tract(fn + ".F5A")
 
         return tracts

--- a/cenpy/legacy_tiger.py
+++ b/cenpy/legacy_tiger.py
@@ -203,11 +203,9 @@ class FTPConnection(object):
         gdf['COUNTY'] = gdf['COUNTY'].astype(str).str.rjust(3, "0")
         gdf['TRACT'] = gdf['TRACT'].astype(str).str.rjust(6, "0")
         gdf['BLOCK'] = gdf['BLOCK'].astype(str).str.rjust(4, "0")
-
+        gdf['fips'] = gdf.STATE + gdf.COUNTY + gdf.TRACT
         if self.geom == 'block':
-            gdf['fips'] = gdf.STATE + gdf.COUNTY + gdf.TRACT + gdf.BLOCK
-        else:
-            gdf['fips'] = gdf.STATE + gdf.COUNTY + gdf.TRACT
+            gdf['fips'] += gdf.BLOCK
 
         gdf = gdf.dropna(subset=['fips'])
         gdf.geometry = gdf.buffer(0)

--- a/cenpy/legacy_tiger.py
+++ b/cenpy/legacy_tiger.py
@@ -9,217 +9,219 @@ import os
 import tempfile
 
 
-def tiger_to_tract(infile):
-
-    # Modified from original at
-    # https://svn.osgeo.org/gdal/tags/1.4.3/gdal/pymod/samples/tigerpoly.py
-
-    class Module:
-        def __init__(self):
-            self.lines = {}
-            self.poly_line_links = {}
-
-    outfile = 'tracts.shp'
-
-    # Open the datasource to operate on.
-
-    ds = ogr.Open(infile, update=0)
-    poly_layer = ds.GetLayerByName('Polygon')
-
-    # Create output file for the composed polygons.
-
-    nad83 = osr.SpatialReference()
-    nad83.SetFromUserInput('NAD83')
-
-    shp_driver = ogr.GetDriverByName('ESRI Shapefile')
-    shp_driver.DeleteDataSource(outfile)
-
-    shp_ds = shp_driver.CreateDataSource(outfile)
-
-    shp_layer = shp_ds.CreateLayer('out', geom_type=ogr.wkbPolygon, srs=nad83)
-
-    src_defn = poly_layer.GetLayerDefn()
-    poly_field_count = src_defn.GetFieldCount()
-
-    for fld_index in range(poly_field_count):
-        src_fd = src_defn.GetFieldDefn(fld_index)
-
-        fd = ogr.FieldDefn(src_fd.GetName(), src_fd.GetType())
-        fd.SetWidth(src_fd.GetWidth())
-        fd.SetPrecision(src_fd.GetPrecision())
-        shp_layer.CreateField(fd)
-
-    # Read all features in the line layer, holding just the geometry in a hash
-    # for fast lookup by TLID.
-
-    line_layer = ds.GetLayerByName('CompleteChain')
-    line_count = 0
-
-    modules_hash = {}
-
-    feat = line_layer.GetNextFeature()
-    geom_id_field = feat.GetFieldIndex('TLID')
-    tile_ref_field = feat.GetFieldIndex('MODULE')
-    while feat is not None:
-        geom_id = feat.GetField(geom_id_field)
-        tile_ref = feat.GetField(tile_ref_field)
-
-        try:
-            module = modules_hash[tile_ref]
-        except:
-            module = Module()
-            modules_hash[tile_ref] = module
-
-        module.lines[geom_id] = feat.GetGeometryRef().Clone()
-        line_count = line_count + 1
-
-        feat.Destroy()
-
-        feat = line_layer.GetNextFeature()
-
-    # Read all polygon/chain links and build a hash keyed by POLY_ID listing
-    # the chains (by TLID) attached to it.
-
-    link_layer = ds.GetLayerByName('PolyChainLink')
-
-    feat = link_layer.GetNextFeature()
-    geom_id_field = feat.GetFieldIndex('TLID')
-    tile_ref_field = feat.GetFieldIndex('MODULE')
-    lpoly_field = feat.GetFieldIndex('POLYIDL')
-    rpoly_field = feat.GetFieldIndex('POLYIDR')
-
-    link_count = 0
-
-    while feat is not None:
-        module = modules_hash[feat.GetField(tile_ref_field)]
-
-        tlid = feat.GetField(geom_id_field)
-
-        lpoly_id = feat.GetField(lpoly_field)
-        rpoly_id = feat.GetField(rpoly_field)
-
-        if lpoly_id == rpoly_id:
-            feat.Destroy()
-            feat = link_layer.GetNextFeature()
-            continue
-
-        try:
-            module.poly_line_links[lpoly_id].append(tlid)
-        except:
-            module.poly_line_links[lpoly_id] = [tlid]
-
-        try:
-            module.poly_line_links[rpoly_id].append(tlid)
-        except:
-            module.poly_line_links[rpoly_id] = [tlid]
-
-        link_count = link_count + 1
-
-        feat.Destroy()
-
-        feat = link_layer.GetNextFeature()
-
-    # Process all polygon features.
-
-    feat = poly_layer.GetNextFeature()
-    tile_ref_field = feat.GetFieldIndex('MODULE')
-    polyid_field = feat.GetFieldIndex('POLYID')
-
-    poly_count = 0
-    degenerate_count = 0
-
-    while feat is not None:
-        module = modules_hash[feat.GetField(tile_ref_field)]
-        polyid = feat.GetField(polyid_field)
-
-        tlid_list = module.poly_line_links[polyid]
-
-        link_coll = ogr.Geometry(type=ogr.wkbGeometryCollection)
-        for tlid in tlid_list:
-            geom = module.lines[tlid]
-            link_coll.AddGeometry(geom)
-
-        try:
-            poly = ogr.BuildPolygonFromEdges(link_coll)
-
-            if poly.GetGeometryRef(0).GetPointCount() < 4:
-                degenerate_count = degenerate_count + 1
-                poly.Destroy()
-                feat.Destroy()
-                feat = poly_layer.GetNextFeature()
-                continue
-
-            # print poly.ExportToWkt()
-            # feat.SetGeometryDirectly( poly )
-
-            feat2 = ogr.Feature(feature_def=shp_layer.GetLayerDefn())
-
-            for fld_index in range(poly_field_count):
-                feat2.SetField(fld_index, feat.GetField(fld_index))
-
-            feat2.SetGeometryDirectly(poly)
-
-            shp_layer.CreateFeature(feat2)
-            feat2.Destroy()
-
-            poly_count = poly_count + 1
-        except:
-            warn('BuildPolygonFromEdges failed.')
-
-        feat.Destroy()
-
-        feat = poly_layer.GetNextFeature()
-
-    if degenerate_count:
-        warn('Discarded %d degenerate polygons.' % degenerate_count)
-
-    print('Built %d polygons.' % poly_count)
-
-    # Cleanup
-
-    shp_ds.Destroy()
-    ds.Destroy()
-
-    # build a fully-qualified fips code and dissolve on it to create tract geographies
-    gdf = gpd.read_file(outfile)
-
-    if "CTBNA90" in gdf.columns:
-
-        gdf = gdf.rename(columns={"CTBNA90": 'TRACT'})
-
-    gdf['STATE'] = gdf['STATE'].astype(str).str.rjust(2, "0")
-    gdf['COUNTY'] = gdf['COUNTY'].astype(str).str.rjust(3, "0")
-    gdf['TRACT'] = gdf['TRACT'].astype(str).str.rjust(4, "0")
-    gdf['fips'] = gdf.STATE + gdf.COUNTY + gdf.TRACT + '00'
-
-    gdf = gdf.dropna(subset=['fips'])
-    gdf.geometry = gdf.buffer(0)
-    gdf = gdf.dissolve(by='fips')
-    gdf.reset_index(inplace=True)
-
-    gdf.to_file(outfile)
-
-    return gdf
-
-
 class FTPConnection(object):
 
     def __init__(self, year, statenum, stateabbr, county):
 
-        self.url = 'ftp://ftp2.census.gov/geo/tiger/TIGER{year}/{statenum}_{stateabbr}/tgr{statenum}{county}.zip' .format(year=year, statenum=statenum, stateabbr=stateabbr, county=county)
-        self.year = year
+        url = {2000: 'ftp://ftp2.census.gov/geo/tiger/TIGER2003/{statenum}_{stateabbr}/tgr{statenum}{county}.zip' .format(statenum=statenum, stateabbr=stateabbr, county=county),
+               1990: 'ftp://ftp2.census.gov/geo/tiger/TIGER1992/{statenum}/{statenum}{county}.zip' .format(statenum=statenum, stateabbr=stateabbr, county=county)
+               }
+
+        self.url = url[year]
         self.statenum = statenum
         self.stateabbr = stateabbr
         self.county = county
+
+    def _tiger_to_tract(self, infile):
+
+        # Modified from original at
+        # https://svn.osgeo.org/gdal/tags/1.4.3/gdal/pymod/samples/tigerpoly.py
+
+        class Module:
+            def __init__(self):
+                self.lines = {}
+                self.poly_line_links = {}
+
+        outfile = 'tracts.shp'
+
+        # Open the datasource to operate on.
+        ds = ogr.Open(infile, update=0)
+        poly_layer = ds.GetLayerByName('Polygon')
+
+        # Create output file for the composed polygons.
+        nad83 = osr.SpatialReference()
+        nad83.SetFromUserInput('NAD83')
+
+        shp_driver = ogr.GetDriverByName('ESRI Shapefile')
+        shp_driver.DeleteDataSource(outfile)
+
+        shp_ds = shp_driver.CreateDataSource(outfile)
+        shp_layer = shp_ds.CreateLayer('out', geom_type=ogr.wkbPolygon, srs=nad83)
+
+        src_defn = poly_layer.GetLayerDefn()
+        poly_field_count = src_defn.GetFieldCount()
+
+        for fld_index in range(poly_field_count):
+            src_fd = src_defn.GetFieldDefn(fld_index)
+
+            fd = ogr.FieldDefn(src_fd.GetName(), src_fd.GetType())
+            fd.SetWidth(src_fd.GetWidth())
+            fd.SetPrecision(src_fd.GetPrecision())
+            shp_layer.CreateField(fd)
+
+        # Read all features in the line layer, holding just the geometry in a hash
+        # for fast lookup by TLID.
+
+        line_layer = ds.GetLayerByName('CompleteChain')
+        line_count = 0
+
+        modules_hash = {}
+
+        feat = line_layer.GetNextFeature()
+        geom_id_field = feat.GetFieldIndex('TLID')
+        tile_ref_field = feat.GetFieldIndex('MODULE')
+        while feat is not None:
+            geom_id = feat.GetField(geom_id_field)
+            tile_ref = feat.GetField(tile_ref_field)
+
+            try:
+                module = modules_hash[tile_ref]
+            except:
+                module = Module()
+                modules_hash[tile_ref] = module
+
+            module.lines[geom_id] = feat.GetGeometryRef().Clone()
+            line_count = line_count + 1
+
+            feat.Destroy()
+
+            feat = line_layer.GetNextFeature()
+
+        # Read all polygon/chain links and build a hash keyed by POLY_ID listing
+        # the chains (by TLID) attached to it.
+
+        link_layer = ds.GetLayerByName('PolyChainLink')
+
+        feat = link_layer.GetNextFeature()
+        geom_id_field = feat.GetFieldIndex('TLID')
+        tile_ref_field = feat.GetFieldIndex('MODULE')
+        lpoly_field = feat.GetFieldIndex('POLYIDL')
+        rpoly_field = feat.GetFieldIndex('POLYIDR')
+
+        link_count = 0
+
+        while feat is not None:
+            module = modules_hash[feat.GetField(tile_ref_field)]
+
+            tlid = feat.GetField(geom_id_field)
+
+            lpoly_id = feat.GetField(lpoly_field)
+            rpoly_id = feat.GetField(rpoly_field)
+
+            if lpoly_id == rpoly_id:
+                feat.Destroy()
+                feat = link_layer.GetNextFeature()
+                continue
+
+            try:
+                module.poly_line_links[lpoly_id].append(tlid)
+            except:
+                module.poly_line_links[lpoly_id] = [tlid]
+
+            try:
+                module.poly_line_links[rpoly_id].append(tlid)
+            except:
+                module.poly_line_links[rpoly_id] = [tlid]
+
+            link_count = link_count + 1
+
+            feat.Destroy()
+
+            feat = link_layer.GetNextFeature()
+
+        # Process all polygon features.
+
+        feat = poly_layer.GetNextFeature()
+        tile_ref_field = feat.GetFieldIndex('MODULE')
+        polyid_field = feat.GetFieldIndex('POLYID')
+
+        poly_count = 0
+        degenerate_count = 0
+
+        while feat is not None:
+            module = modules_hash[feat.GetField(tile_ref_field)]
+            polyid = feat.GetField(polyid_field)
+
+            tlid_list = module.poly_line_links[polyid]
+
+            link_coll = ogr.Geometry(type=ogr.wkbGeometryCollection)
+            for tlid in tlid_list:
+                geom = module.lines[tlid]
+                link_coll.AddGeometry(geom)
+
+            try:
+                poly = ogr.BuildPolygonFromEdges(link_coll)
+
+                if poly.GetGeometryRef(0).GetPointCount() < 4:
+                    degenerate_count = degenerate_count + 1
+                    poly.Destroy()
+                    feat.Destroy()
+                    feat = poly_layer.GetNextFeature()
+                    continue
+
+                # print poly.ExportToWkt()
+                # feat.SetGeometryDirectly( poly )
+
+                feat2 = ogr.Feature(feature_def=shp_layer.GetLayerDefn())
+
+                for fld_index in range(poly_field_count):
+                    feat2.SetField(fld_index, feat.GetField(fld_index))
+
+                feat2.SetGeometryDirectly(poly)
+
+                shp_layer.CreateFeature(feat2)
+                feat2.Destroy()
+
+                poly_count = poly_count + 1
+            except:
+                warn('BuildPolygonFromEdges failed.')
+
+            feat.Destroy()
+
+            feat = poly_layer.GetNextFeature()
+
+        if degenerate_count:
+            warn('Discarded %d degenerate polygons.' % degenerate_count)
+
+        print('Built %d polygons.' % poly_count)
+
+        # Cleanup
+
+        shp_ds.Destroy()
+        ds.Destroy()
+
+        # build a fully-qualified fips code and dissolve on it to create tract geographies
+        gdf = gpd.read_file(outfile)
+
+        if "CTBNA90" in gdf.columns:
+
+            gdf = gdf.rename(columns={"CTBNA90": 'TRACT'})
+
+        gdf['STATE'] = gdf['STATE'].astype(str).str.rjust(2, "0")
+        gdf['COUNTY'] = gdf['COUNTY'].astype(str).str.rjust(3, "0")
+        gdf['TRACT'] = gdf['TRACT'].astype(str).str.rjust(4, "0")
+        gdf['fips'] = gdf.STATE + gdf.COUNTY + gdf.TRACT + '00'
+
+        gdf = gdf.dropna(subset=['fips'])
+        gdf.geometry = gdf.buffer(0)
+        gdf = gdf.dissolve(by='fips')
+        gdf.reset_index(inplace=True)
+
+        gdf.to_file(outfile)
+
+        return gdf
 
     def query(self):
 
         with urlopen(self.url) as response:
             with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
                 shutil.copyfileobj(response, tmp_file)
-                print(tmp_file)
                 with tempfile.TemporaryDirectory() as tempdir:
                     ZipFile(tmp_file, 'r').extractall(tempdir)
-                    tracts = tiger_to_tract(os.path.join(tempdir, "TGR{statenum}{county}.RTA" .format(statenum=self.statenum, county=self.county)))
+                    fn = os.path.join(tempdir,"TGR{statenum}{county}" .format(statenum=self.statenum, county=self.county))
+                    if os.path.exists(fn+".RTA"):
+                        tracts = self._tiger_to_tract(fn+".RTA")
+                    else:
+                        tracts = self._tiger_to_tract(fn+".F5A")
 
         return tracts

--- a/cenpy/legacy_tiger.py
+++ b/cenpy/legacy_tiger.py
@@ -1,0 +1,225 @@
+import geopandas as gpd
+from warnings import warn
+from gdal import osr, ogr
+import shutil
+
+from urllib.request import urlopen
+from zipfile import ZipFile
+import os
+import tempfile
+
+
+def tiger_to_tract(infile):
+
+    # Modified from original at
+    # https://svn.osgeo.org/gdal/tags/1.4.3/gdal/pymod/samples/tigerpoly.py
+
+    class Module:
+        def __init__(self):
+            self.lines = {}
+            self.poly_line_links = {}
+
+    outfile = 'tracts.shp'
+
+    # Open the datasource to operate on.
+
+    ds = ogr.Open(infile, update=0)
+    poly_layer = ds.GetLayerByName('Polygon')
+
+    # Create output file for the composed polygons.
+
+    nad83 = osr.SpatialReference()
+    nad83.SetFromUserInput('NAD83')
+
+    shp_driver = ogr.GetDriverByName('ESRI Shapefile')
+    shp_driver.DeleteDataSource(outfile)
+
+    shp_ds = shp_driver.CreateDataSource(outfile)
+
+    shp_layer = shp_ds.CreateLayer('out', geom_type=ogr.wkbPolygon, srs=nad83)
+
+    src_defn = poly_layer.GetLayerDefn()
+    poly_field_count = src_defn.GetFieldCount()
+
+    for fld_index in range(poly_field_count):
+        src_fd = src_defn.GetFieldDefn(fld_index)
+
+        fd = ogr.FieldDefn(src_fd.GetName(), src_fd.GetType())
+        fd.SetWidth(src_fd.GetWidth())
+        fd.SetPrecision(src_fd.GetPrecision())
+        shp_layer.CreateField(fd)
+
+    # Read all features in the line layer, holding just the geometry in a hash
+    # for fast lookup by TLID.
+
+    line_layer = ds.GetLayerByName('CompleteChain')
+    line_count = 0
+
+    modules_hash = {}
+
+    feat = line_layer.GetNextFeature()
+    geom_id_field = feat.GetFieldIndex('TLID')
+    tile_ref_field = feat.GetFieldIndex('MODULE')
+    while feat is not None:
+        geom_id = feat.GetField(geom_id_field)
+        tile_ref = feat.GetField(tile_ref_field)
+
+        try:
+            module = modules_hash[tile_ref]
+        except:
+            module = Module()
+            modules_hash[tile_ref] = module
+
+        module.lines[geom_id] = feat.GetGeometryRef().Clone()
+        line_count = line_count + 1
+
+        feat.Destroy()
+
+        feat = line_layer.GetNextFeature()
+
+    # Read all polygon/chain links and build a hash keyed by POLY_ID listing
+    # the chains (by TLID) attached to it.
+
+    link_layer = ds.GetLayerByName('PolyChainLink')
+
+    feat = link_layer.GetNextFeature()
+    geom_id_field = feat.GetFieldIndex('TLID')
+    tile_ref_field = feat.GetFieldIndex('MODULE')
+    lpoly_field = feat.GetFieldIndex('POLYIDL')
+    rpoly_field = feat.GetFieldIndex('POLYIDR')
+
+    link_count = 0
+
+    while feat is not None:
+        module = modules_hash[feat.GetField(tile_ref_field)]
+
+        tlid = feat.GetField(geom_id_field)
+
+        lpoly_id = feat.GetField(lpoly_field)
+        rpoly_id = feat.GetField(rpoly_field)
+
+        if lpoly_id == rpoly_id:
+            feat.Destroy()
+            feat = link_layer.GetNextFeature()
+            continue
+
+        try:
+            module.poly_line_links[lpoly_id].append(tlid)
+        except:
+            module.poly_line_links[lpoly_id] = [tlid]
+
+        try:
+            module.poly_line_links[rpoly_id].append(tlid)
+        except:
+            module.poly_line_links[rpoly_id] = [tlid]
+
+        link_count = link_count + 1
+
+        feat.Destroy()
+
+        feat = link_layer.GetNextFeature()
+
+    # Process all polygon features.
+
+    feat = poly_layer.GetNextFeature()
+    tile_ref_field = feat.GetFieldIndex('MODULE')
+    polyid_field = feat.GetFieldIndex('POLYID')
+
+    poly_count = 0
+    degenerate_count = 0
+
+    while feat is not None:
+        module = modules_hash[feat.GetField(tile_ref_field)]
+        polyid = feat.GetField(polyid_field)
+
+        tlid_list = module.poly_line_links[polyid]
+
+        link_coll = ogr.Geometry(type=ogr.wkbGeometryCollection)
+        for tlid in tlid_list:
+            geom = module.lines[tlid]
+            link_coll.AddGeometry(geom)
+
+        try:
+            poly = ogr.BuildPolygonFromEdges(link_coll)
+
+            if poly.GetGeometryRef(0).GetPointCount() < 4:
+                degenerate_count = degenerate_count + 1
+                poly.Destroy()
+                feat.Destroy()
+                feat = poly_layer.GetNextFeature()
+                continue
+
+            # print poly.ExportToWkt()
+            # feat.SetGeometryDirectly( poly )
+
+            feat2 = ogr.Feature(feature_def=shp_layer.GetLayerDefn())
+
+            for fld_index in range(poly_field_count):
+                feat2.SetField(fld_index, feat.GetField(fld_index))
+
+            feat2.SetGeometryDirectly(poly)
+
+            shp_layer.CreateFeature(feat2)
+            feat2.Destroy()
+
+            poly_count = poly_count + 1
+        except:
+            warn('BuildPolygonFromEdges failed.')
+
+        feat.Destroy()
+
+        feat = poly_layer.GetNextFeature()
+
+    if degenerate_count:
+        warn('Discarded %d degenerate polygons.' % degenerate_count)
+
+    print('Built %d polygons.' % poly_count)
+
+    # Cleanup
+
+    shp_ds.Destroy()
+    ds.Destroy()
+
+    # build a fully-qualified fips code and dissolve on it to create tract geographies
+    gdf = gpd.read_file(outfile)
+
+    if "CTBNA90" in gdf.columns:
+
+        gdf = gdf.rename(columns={"CTBNA90": 'TRACT'})
+
+    gdf['STATE'] = gdf['STATE'].astype(str).str.rjust(2, "0")
+    gdf['COUNTY'] = gdf['COUNTY'].astype(str).str.rjust(3, "0")
+    gdf['TRACT'] = gdf['TRACT'].astype(str).str.rjust(4, "0")
+    gdf['fips'] = gdf.STATE + gdf.COUNTY + gdf.TRACT + '00'
+
+    gdf = gdf.dropna(subset=['fips'])
+    gdf.geometry = gdf.buffer(0)
+    gdf = gdf.dissolve(by='fips')
+    gdf.reset_index(inplace=True)
+
+    gdf.to_file(outfile)
+
+    return gdf
+
+
+class FTPConnection(object):
+
+    def __init__(self, year, statenum, stateabbr, county):
+
+        self.url = 'ftp://ftp2.census.gov/geo/tiger/TIGER{year}/{statenum}_{stateabbr}/tgr{statenum}{county}.zip' .format(year=year, statenum=statenum, stateabbr=stateabbr, county=county)
+        self.year = year
+        self.statenum = statenum
+        self.stateabbr = stateabbr
+        self.county = county
+
+    def query(self):
+
+        with urlopen(self.url) as response:
+            with tempfile.NamedTemporaryFile(delete=False) as tmp_file:
+                shutil.copyfileobj(response, tmp_file)
+                print(tmp_file)
+                with tempfile.TemporaryDirectory() as tempdir:
+                    ZipFile(tmp_file, 'r').extractall(tempdir)
+                    tracts = tiger_to_tract(os.path.join(tempdir, "TGR{statenum}{county}.RTA" .format(statenum=self.statenum, county=self.county)))
+
+        return tracts

--- a/cenpy/tools.py
+++ b/cenpy/tools.py
@@ -7,13 +7,16 @@ from requests import HTTPError
 try:
     from tqdm import tqdm
 except ImportError:
+
     def tqdm(arg, **kwargs):
         return arg
-_state_fipscodes = _ft('state')['FIPS Code']
-_state_fipscodes = [str(f).rjust(2, '0') for f in _state_fipscodes if f < 60] 
 
-def national_to_block(cxn, *columns, wait_by_state=0, 
-                                     wait_by_county=0):
+
+_state_fipscodes = _ft('state')['FIPS Code']
+_state_fipscodes = [str(f).rjust(2, '0') for f in _state_fipscodes if f < 60]
+
+
+def national_to_block(cxn, *columns, wait_by_state=0, wait_by_county=0):
     """
     A helper function to grab all blocks by iterating over state fips codes in cenpy.explorer.fips_table. 
     This just naively calls state_to_block for each state, so will end up executing quite a few queries. 
@@ -40,42 +43,45 @@ def national_to_block(cxn, *columns, wait_by_state=0,
                     wait time (or wait time callable) applied between each county-level query. See wait_by_state for more information. If this value tends to be large, the time it takes to conduct the query can get large quickly. 
     """
     if isinstance(wait_by_state, (int, float)):
-        waitfunc = lambda : wait_by_state
+        waitfunc = lambda: wait_by_state
     else:
         waitfunc = wait_by_state
     outs = []
     for fp in tqdm(_state_fipscodes):
         print(fp)
         try:
-            outs.append(state_to_block(fp, cxn, *columns, 
-                                       wait=wait_by_county))
+            outs.append(state_to_block(fp, cxn, *columns, wait=wait_by_county))
         except HTTPError:
-            warn.warn('Something failed in state {}, terminating prematurely'.format(fp))
+            warn.warn(
+                'Something failed in state {}, terminating prematurely'.format(
+                    fp))
             raise
         time.sleep(waitfunc())
     return pd.concat(outs)
 
-def national_to_tract(cxn, *columns, wait_by_state = 0,
-                                     wait_by_county = 0):
+
+def national_to_tract(cxn, *columns, wait_by_state=0, wait_by_county=0):
     """
     A helper function to grab all tracts by iterating over state fips codes in cenpy.explorer.fips_table. 
     This just naively calls state_to_tract for each state, so will end up executing quite a few queries. 
     You may be rate limited if you don't use an APIKEY
     """
     if isinstance(wait_by_state, (int, float)):
-        waitfunc = lambda : wait_by_state
+        waitfunc = lambda: wait_by_state
     else:
         waitfunc = wait_by_state
     outs = []
     for fp in _state_fipscodes:
         try:
-            outs.append(state_to_tract(fp, cxn, *columns, 
-                                       wait=wait_by_county))
+            outs.append(state_to_tract(fp, cxn, *columns, wait=wait_by_county))
         except HTTPError:
-            warn.warn('Something failed in state {}, terminating prematurely'.format(fp))
+            warn.warn(
+                'Something failed in state {}, terminating prematurely'.format(
+                    fp))
             raise
         time.sleep(waitfunc())
     return pd.concat(outs)
+
 
 def national_to_blockgroup(cxn, *columns, wait_by_state=0, wait_by_county=0):
     """
@@ -84,18 +90,22 @@ def national_to_blockgroup(cxn, *columns, wait_by_state=0, wait_by_county=0):
     You may be rate limited if you don't use an APIKEY
     """
     if isinstance(wait_by_state, (int, float)):
-        wait_by_state = lambda : wait_by_state
+        wait_by_state = lambda: wait_by_state
     else:
         waitfunc = wait_by_state
     outs = []
     for fp in _state_fipscodes:
         try:
-            outs.append(state_to_blockgroup(fp, cxn, *columns, wait=wait_by_county))
+            outs.append(
+                state_to_blockgroup(fp, cxn, *columns, wait=wait_by_county))
         except HTTPError:
-            warn.warn('Something failed in state {}, terminating prematurely'.format(fp))
+            warn.warn(
+                'Something failed in state {}, terminating prematurely'.format(
+                    fp))
             raise
         time.sleep(waitfunc(a))
     return pd.concat(outs)
+
 
 def state_to_block(stfips, cxn, *columns, wait=0):
     """
@@ -103,7 +113,7 @@ def state_to_block(stfips, cxn, *columns, wait=0):
     For arguments, see genstate_to_block
     """
     if isinstance(wait, (int, float)):
-        waitfunc = lambda : wait
+        waitfunc = lambda: wait
     else:
         waitfunc = wait
     out = []
@@ -112,13 +122,14 @@ def state_to_block(stfips, cxn, *columns, wait=0):
         time.sleep(waitfunc())
     return pd.concat(out)
 
+
 def state_to_blockgroup(stfips, cxn, *columns, wait=0):
     """
     Casts the generator constructed by genstate_to_blockgroup to a full dataframe. 
     For arguments, see genstate_to_blockgroup
     """
     if isinstance(wait, (int, float)):
-        waitfunc = lambda : wait
+        waitfunc = lambda: wait
     else:
         waitfunc = wait
     out = []
@@ -126,6 +137,7 @@ def state_to_blockgroup(stfips, cxn, *columns, wait=0):
         out.append(cblock)
         time.sleep(waitfunc())
     return pd.concat(out)
+
 
 def state_to_tract(stfips, cxn, *columns, wait=0):
     """
@@ -150,7 +162,7 @@ def state_to_tract(stfips, cxn, *columns, wait=0):
     For arguments, see genstate_to_tract
     """
     if isinstance(wait, (int, float)):
-        waitfunc = lambda : wait
+        waitfunc = lambda: wait
     else:
         waitfunc = wait
     out = []
@@ -158,6 +170,7 @@ def state_to_tract(stfips, cxn, *columns, wait=0):
         out.append(cblock)
         time.sleep(waitfunc())
     return pd.concat(out)
+
 
 def county_to_block(stfips, ctfips, cxn, *columns, wait=0):
     """
@@ -174,7 +187,7 @@ def county_to_block(stfips, ctfips, cxn, *columns, wait=0):
     dataframe containing the entries of columns for each block. 
     """
     if isinstance(wait, (int, float)):
-        waitfunc = lambda : wait
+        waitfunc = lambda: wait
     else:
         waitfunc = wait
     out = []
@@ -182,6 +195,7 @@ def county_to_block(stfips, ctfips, cxn, *columns, wait=0):
         out.append(cblock)
         time.sleep(waitfunc())
     return pd.concat(out)
+
 
 def genstate_to_block(stfips, cxn, *columns):
     """
@@ -199,17 +213,27 @@ def genstate_to_block(stfips, cxn, *columns):
     -------
     a Generator that yields dataframes.
     """
-    counties = cxn.query(['NAME'], geo_unit='county', geo_filter={'state':stfips})
+    counties = cxn.query(
+        ['AREALAND'], geo_unit='county', geo_filter={'state': stfips})
     counties = counties.county.tolist()
-    ctracts = ((county, tract) for county in counties 
-                for tract in cxn.query(['NAME'], geo_unit='tract', 
-                                       geo_filter={'state':stfips, 'county':county}).tract)
-    for county,tract in tqdm(ctracts):
-        blocks = cxn.query(['NAME'] + list(columns), geo_unit='block', 
-                           geo_filter={'state':stfips, 
-                                       'county':county,
-                                       'tract':tract})
+    ctracts = ((county, tract) for county in counties for tract in cxn.query(
+        ['AREALAND'],
+        geo_unit='tract',
+        geo_filter={
+            'state': stfips,
+            'county': county
+        }).tract)
+    for county, tract in tqdm(ctracts):
+        blocks = cxn.query(
+            ['AREALAND'] + list(columns),
+            geo_unit='block',
+            geo_filter={
+                'state': stfips,
+                'county': county,
+                'tract': tract
+            })
         yield blocks
+
 
 def gencounty_to_block(stfips, ctfips, cxn, *columns):
     """
@@ -229,12 +253,17 @@ def gencounty_to_block(stfips, ctfips, cxn, *columns):
     -------
     a Generator that yields dataframes
     """
-    start_filter = dict(state=str(stfips).rjust(2, '0'), county=str(ctfips).rjust(3, '0'))
-    tracts = cxn.query(['NAME'], geo_unit='tract', geo_filter=start_filter)
+    start_filter = dict(
+        state=str(stfips).rjust(2, '0'), county=str(ctfips).rjust(3, '0'))
+    tracts = cxn.query(['AREALAND'], geo_unit='tract', geo_filter=start_filter)
     for tract in tqdm(tracts.tract):
         start_filter.update(dict(tract=tract))
-        blocks = cxn.query(['NAME'] + list(columns), geo_unit = 'block', geo_filter = start_filter)
+        blocks = cxn.query(
+            ['AREALAND'] + list(columns),
+            geo_unit='block',
+            geo_filter=start_filter)
         yield blocks
+
 
 def genstate_to_blockgroup(stfips, cxn, *columns):
     """
@@ -252,17 +281,27 @@ def genstate_to_blockgroup(stfips, cxn, *columns):
     -------
     a Generator that yields dataframes.
     """
-    counties = cxn.query(['NAME'], geo_unit='county', geo_filter={'state':stfips})
+    counties = cxn.query(
+        ['AREALAND'], geo_unit='county', geo_filter={'state': stfips})
     counties = counties.county.tolist()
-    ctracts = ((county, tract) for county in counties 
-                for tract in cxn.query(['NAME'], geo_unit='tract', 
-                                       geo_filter={'state':stfips, 'county':county}).tract)
-    for county,tract in tqdm(ctracts):
-        blockgroups = cxn.query(['NAME'] + list(columns), geo_unit='blockgroup', 
-                           geo_filter={'state':stfips, 
-                                       'county':county,
-                                       'tract':tract})
+    ctracts = ((county, tract) for county in counties for tract in cxn.query(
+        ['AREALAND'],
+        geo_unit='tract',
+        geo_filter={
+            'state': stfips,
+            'county': county
+        }).tract)
+    for county, tract in tqdm(ctracts):
+        blockgroups = cxn.query(
+            ['AREALAND'] + list(columns),
+            geo_unit='blockgroup',
+            geo_filter={
+                'state': stfips,
+                'county': county,
+                'tract': tract
+            })
         yield blockgroups
+
 
 def genstate_to_tract(stfips, cxn, *columns):
     """
@@ -280,13 +319,19 @@ def genstate_to_tract(stfips, cxn, *columns):
     -------
     a Generator that yields dataframes.
     """
-    counties = cxn.query(['NAME'], geo_unit='county', geo_filter={'state':stfips})
+    counties = cxn.query(
+        ['AREALAND'], geo_unit='county', geo_filter={'state': stfips})
     counties = counties.county.tolist()
     for county in tqdm(counties):
-        tract = cxn.query(['NAME'] + list(columns), geo_unit='tract', 
-                           geo_filter={'state':stfips, 
-                                       'county':county})
+        tract = cxn.query(
+            *columns,
+            geo_unit='tract',
+            geo_filter={
+                'state': stfips,
+                'county': county
+            })
         yield tract
+
 
 def set_sitekey(sitekey, overwrite=False):
     """
@@ -308,10 +353,12 @@ def set_sitekey(sitekey, overwrite=False):
     targetpath = os.path.join(thispath, 'SITEKEY.txt')
     if os.path.isfile(targetpath):
         if not overwrite:
-            raise FileError('SITEKEY already bound and overwrite flag is not set')
+            raise FileError(
+                'SITEKEY already bound and overwrite flag is not set')
     with open(targetpath, 'w') as outfile:
         outfile.write(sitekey)
     return targetpath
+
 
 def _load_sitekey():
     basepath = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
these are the bones of a class adding support for legacy TIGER files for building historic datasets

currently it will collect the TIGER files for a single county from the Census FTP, dissolve them into tract boundaries, and return a geodataframe

To to:

1. [ ] use conventions in `explorer.py` to support more complex queries, recursion through counties
2. [x] support for blocks, other geographies
3. [ ] documentation
3. [ ] tests 