### PR TITLE
remove premature raise_for_status

### DIFF
--- a/cenpy/remote.py
+++ b/cenpy/remote.py
@@ -167,7 +167,6 @@ class APIConnection():
                                         for k, v in iteritems(kwargs)])
 
         res = r.get(self.last_query)
-        res.raise_for_status()
         if res.status_code == 204:
             raise r.HTTPError(str(res.status_code) +
                               ' error: no records matched your query')


### PR DESCRIPTION
this should enable the existing code where I tried to introspect meaningful error messages to actually work. 

I was prematurely `raise_for_status()`-ing, which forced the error. This should fix the behavior mentioned in #33 

