### PR TITLE
Product nogeom

### DIFF
--- a/cenpy/tiger.py
+++ b/cenpy/tiger.py
@@ -155,7 +155,7 @@ class ESRILayer(object):
         datadict = resp.json()
         if raw:
             return datadict
-        if kwargs.get('returnGeometry', True) is False:
+        if kwargs.get('returnGeometry', 'true') is 'false':
             return pd.DataFrame.from_records([x['attributes'] for x in datadict['features']])
     # convert to output format
         try:


### PR DESCRIPTION
This includes all the relevant changes to drop geometries from the queries. 

It's simpler to fetch the geometries, but drop them if the user only wants to keep around the shapes. This is because the spatial join is easier to work in geopandas than in the GeoAPI. 